### PR TITLE
QRコードの古い写真を削除するなど

### DIFF
--- a/commands/Reset_QRCode.js
+++ b/commands/Reset_QRCode.js
@@ -71,6 +71,7 @@ module.exports = {
 
       // QRコードのリセット処理をここに実装
       await DeleteAllQRCodes();
+      await DeleteQRCodesImages();// 画像も削除
 
       await buttonInteraction.update({
         content: 'QRコードをリセットしました。',
@@ -95,3 +96,25 @@ module.exports = {
     }
   },
 };
+
+async function DeleteQRCodesImages() {
+  const qrCodesDir = 'qrcodes';
+  try {
+    if (!fs.existsSync(qrCodesDir)) return;
+    const files = await fs.promises.readdir(qrCodesDir);
+    for (const file of files) {
+      // .gitkeep は残す
+      if (file === '.gitkeep') continue;
+      const filePath = `${qrCodesDir}/${file}`;
+      try {
+        const stat = await fs.promises.stat(filePath);
+        if (stat.isFile()) await fs.promises.unlink(filePath);
+      } catch (e) {
+        console.error('Failed to delete file:', filePath, e);
+      }
+    }
+  } catch (err) {
+    console.error('DeleteQRCodesImages error:', err);
+  }
+}
+  

--- a/commands/newpay.js
+++ b/commands/newpay.js
@@ -12,8 +12,8 @@ const execFileAsync = promisify(execFile);
 
 module.exports = {
     data: new SlashCommandBuilder()
-        .setName('newpay')
-        .setDescription('DMで受信した画像のQRコードを外部デコーダーで読み取ります。'),
+        .setName('pay')
+        .setDescription('会費を支払います。DMで受信した画像のQRコードを外部デコーダーで読み取ります。'),
     async execute(interaction) {
         try {
             await interaction.deferReply({ flags: MessageFlags.Ephemeral });
@@ -132,7 +132,7 @@ async function decodeQrWithExternalDecoder(attachment) {
         if (!decodedText) {
             return {
                 ok: false,
-                message: 'QRコードを読み取れませんでした。',
+                message: 'QRコードを読み取れませんでした。少しQRコードを遠ざけて、画面中央にQRコードが収まるようにして、明るい場所で再度写真を撮ってみてください。',
             };
         }
 
@@ -180,7 +180,7 @@ async function decodeQrWithExternalDecoder(attachment) {
         ) {
             return {
                 ok: false,
-                message: 'QRコードを読み取れませんでした。画像を明るく鮮明にして再度お試しください。',
+                message: 'QRコードを読み取れませんでした。少しQRコードを遠ざけて、画面中央にQRコードが収まるようにして、明るい場所で再度写真を撮ってみてください。',
             };
         }
 

--- a/commands/pay.js
+++ b/commands/pay.js
@@ -4,7 +4,7 @@ const { updatePaymentByQRCode } = require('../sqlite');
 
 module.exports = {
     data: new SlashCommandBuilder()
-        .setName('pay')
+        .setName('pay_manually')
         .setDescription('QRコードを読み取り、会費の支払いを完了します。'),
     async execute(interaction) {
         try {

--- a/sqlite.js
+++ b/sqlite.js
@@ -319,7 +319,7 @@ function generateAllQRCodes(outputDir = './qrcodes') {
 
         // QRコードの説明を描画
         ctx.fillText('QRコードを写真に撮って', 50, 300);
-        ctx.fillText('Casる-botに送ってください。', 50, 340);
+        ctx.fillText('会員情報管理BOTに送ってください。', 50, 340);
 
         // 最終的な画像を保存
         const out = fs.createWriteStream(outputFilePath);
@@ -385,7 +385,7 @@ async function generateCustomQRCode(outputFilePath, qrCodeData, price) {
 
         // QRコードの説明を描画
         ctx.fillText('QRコードを写真に撮って', 20, 300);
-        ctx.fillText('Casる-botに送ってください。', 20, 340);
+        ctx.fillText('会員情報管理BOTに送ってください。', 20, 340);
 
         // 最終的な画像を保存
         const out = fs.createWriteStream(outputFilePath);


### PR DESCRIPTION
QRコードをリセットするときにデータベースだけではなく、昔の画像を削除するように調整
昔のpay.jsを/pay_manuallyに
newpay.jsを/payにスラッシュコマンドの名称を変更した。