### PR TITLE
Add DB transaction and error handling for payments

### DIFF
--- a/commands/annouce_register.js
+++ b/commands/annouce_register.js
@@ -1,5 +1,6 @@
 //このファイルは、/registerコマンドを処理します。
 const { SlashCommandBuilder } = require('@discordjs/builders'); // SlashCommandBuilderを読み込む
+const { MessageFlags } = require('discord.js');
 const { getDataBydiscord_id } = require('../sqlite.js'); // sqlite.jsから関数を読み込む
 const { isUserAllowed } = require('../allowedUsers.js'); // allowedUsers.jsをインポート
 
@@ -8,15 +9,17 @@ module.exports = {
         .setName('announce_register') // コマンド名を設定
         .setDescription('まだ登録していない人に登録を催促します'), // コマンドの説明を設定
     async execute(interaction) {
-        // コマンド実行者のDiscord IDを取得
-        const discord_id = interaction.user.id;
         if (!isUserAllowed(interaction.user.id, true)) {
         await interaction.reply({
           content: 'このコマンドは管理者のみ実行できます。',
-          ephemeral: true,
+          flags: MessageFlags.Ephemeral,
         });
         return;
       }
+
+        // 長時間処理の前に応答を確保して Unknown interaction を防ぐ
+        await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+
         const namelist = [];
         const members = await interaction.guild.members.fetch();
 
@@ -35,8 +38,6 @@ module.exports = {
         }
       })
     );
-        await interaction.reply({ content: '登録していない人にDMで登録を催促しました。', ephemeral: true });
-
         await interaction.editReply({
             content: `登録を催促したユーザーの名前: ${namelist.join(', ')}`
         })

--- a/commands/generateQRcode.js
+++ b/commands/generateQRcode.js
@@ -1,7 +1,9 @@
 require('dotenv').config(); // dotenvを読み込む
 const { SlashCommandBuilder } = require('@discordjs/builders');
+const fs = require('fs');
 const { generateRandomString, insertQRCode, generateAllQRCodes,generateCustomQRCode } = require('../sqlite.js'); // sqlite.jsからランダム文字列生成関数を読み込む
 const { isUserAllowed } = require('../allowedUsers.js'); // allowedUsers.jsをインポート
+const path = require('path');
 
 const Number = 30; // QRコードの文字数
 
@@ -26,7 +28,7 @@ module.exports = {
     async execute(interaction) {
         try {
             // 実行者のユーザー名をチェック
-            if (!isUserAllowed(interaction.user.id)) {
+            if (!isUserAllowed(interaction.user.id, true)) { // 管理者のみ許可
                 await interaction.reply({ content: 'このコマンドを実行する権限がありません。', ephemeral: true });
                 return;
             }
@@ -56,10 +58,16 @@ module.exports = {
             // すべてのQRコードをPNG形式で生成
             const generatedFiles = await generateAllQRCodes();
 
+            const qrCodeListPath = path.join(process.cwd(), `generated-qrcodes-${Date.now()}.txt`);
+            fs.writeFileSync(qrCodeListPath, qrCodes.join('\n'), 'utf8');
+
             // 結果を返信
             await interaction.editReply({
-                content: `生成されたQRコード:\n${qrCodes.join('\n')}\nPNGファイルが生成されました (${generatedFiles.length} 件)。`
+                content: `QRコードを${qrCodes.length}件生成しました。PNGファイルも${generatedFiles.length}件生成されました。QRコード一覧は添付ファイルを確認してください。`,
+                files: [qrCodeListPath]
             });
+
+            fs.unlinkSync(qrCodeListPath);
         } catch (error) {
             console.error(error);
 

--- a/commands/get.js
+++ b/commands/get.js
@@ -63,7 +63,7 @@ module.exports = {
                     },
                     {
                         name: "登録日",
-                        value: data.registered_date || "未登録"
+                        value: data.last_register_date || "未登録"
                     },
                     {
                         name: "最終支払日",

--- a/commands/newpay.js
+++ b/commands/newpay.js
@@ -72,6 +72,15 @@ module.exports = {
                     });
 
                     const paymentResult = updatePaymentByQRCode(interaction.user.id, decodeResult.data);
+                    
+                    if (!paymentResult) {
+                        await interaction.followUp({
+                            content: 'システムエラーが発生しました。もう一度お試しください。',
+                            flags: MessageFlags.Ephemeral,
+                        });
+                        return;
+                    }
+                    
                     await interaction.followUp({
                         content: paymentResult.message,
                         flags: MessageFlags.Ephemeral,

--- a/commands/pay.js
+++ b/commands/pay.js
@@ -39,6 +39,15 @@ module.exports = {
             const qrCodeData = submitted.fields.getTextInputValue('Input1');
             console.log('QRコードの内容:', qrCodeData);
             const paymentResult = updatePaymentByQRCode(interaction.user.id, qrCodeData);
+            
+            if (!paymentResult) {
+                await submitted.reply({ 
+                    content: 'システムエラーが発生しました。もう一度お試しください。', 
+                    ephemeral: true 
+                });
+                return;
+            }
+            
             await submitted.reply({ content: paymentResult.message, ephemeral: true });
         } catch (error) {
             console.error('モーダルの待機中にエラーが発生しました:', error);

--- a/commands/register/academic_department.js
+++ b/commands/register/academic_department.js
@@ -87,7 +87,9 @@ async function academic_department(interaction) {
             time: 60000
         });
 
-        await collected.reply(`${collected.values[0]}が選択されました`);
+        // 相互作用トークンを確保して Unknown interaction を防ぐ
+        await collected.defer();
+        await collected.followUp(`${collected.values[0]}が選択されました`);
 
         // セレクターを無効化する
         const disabledSelect = StringSelectMenuBuilder.from(select).setDisabled(true);

--- a/commands/register/academic_department.js
+++ b/commands/register/academic_department.js
@@ -88,7 +88,7 @@ async function academic_department(interaction) {
         });
 
         // 相互作用トークンを確保して Unknown interaction を防ぐ
-        await collected.defer();
+        await collected.deferUpdate();
         await collected.followUp(`${collected.values[0]}が選択されました`);
 
         // セレクターを無効化する

--- a/commands/register/form.js
+++ b/commands/register/form.js
@@ -46,6 +46,9 @@ async function showModal(interaction) {
             time: 600000
         });
 
+        // 相互作用トークンを確保して Unknown interaction を防ぐ
+        await submitted.deferReply();
+
         //入力された情報を取得
         const data1 = submitted.fields.getTextInputValue('Input1');
         const data2 = submitted.fields.getTextInputValue('Input2');
@@ -58,7 +61,7 @@ async function showModal(interaction) {
         list.push(data4);
 
         //入力された情報を表示
-        await submitted.reply(`あなたの入力した情報:\n学籍番号: ${data1}\n氏名: ${data2}\n氏名(ふりがな): ${data3}\nメール: ${data4}`);
+        await submitted.editReply(`あなたの入力した情報:\n学籍番号: ${data1}\n氏名: ${data2}\n氏名(ふりがな): ${data3}\nメール: ${data4}`);
     } catch (error) {//エラーが発生した場合
         console.error(error);
         await interaction.followUp('時間切れです。追加情報が提供されませんでした。');

--- a/commands/register/gender.js
+++ b/commands/register/gender.js
@@ -30,7 +30,9 @@ async function gender(interaction) {
             time: 60000
         });
 
-        await collected.reply(`${collected.values[0]}が選択されました`);
+        // 相互作用トークンを確保して Unknown interaction を防ぐ
+        await collected.defer();
+        await collected.followUp(`${collected.values[0]}が選択されました`);
 
         // セレクターを無効化する
         const disabledSelect = StringSelectMenuBuilder.from(select).setDisabled(true);

--- a/commands/register/gender.js
+++ b/commands/register/gender.js
@@ -31,7 +31,7 @@ async function gender(interaction) {
         });
 
         // 相互作用トークンを確保して Unknown interaction を防ぐ
-        await collected.defer();
+        await collected.deferUpdate();
         await collected.followUp(`${collected.values[0]}が選択されました`);
 
         // セレクターを無効化する

--- a/commands/register/grade.js
+++ b/commands/register/grade.js
@@ -40,7 +40,7 @@ async function grade(interaction) {
         });
 
         // 相互作用トークンを確保して Unknown interaction を防ぐ
-        await collected.defer();
+        await collected.deferUpdate();
         await collected.followUp(`${collected.values[0]}が選択されました`);
 
         // セレクターを無効化する

--- a/commands/register/grade.js
+++ b/commands/register/grade.js
@@ -39,7 +39,9 @@ async function grade(interaction) {
             time: 60000
         });
 
-        await collected.reply(`${collected.values[0]}が選択されました`);
+        // 相互作用トークンを確保して Unknown interaction を防ぐ
+        await collected.defer();
+        await collected.followUp(`${collected.values[0]}が選択されました`);
 
         // セレクターを無効化する
         const disabledSelect = StringSelectMenuBuilder.from(select).setDisabled(true);

--- a/commands/register/team.js
+++ b/commands/register/team.js
@@ -47,7 +47,7 @@ async function team(interaction) {
         });
 
         // 相互作用トークンを確保して Unknown interaction を防ぐ
-        await collected.defer();
+        await collected.deferUpdate();
 
         const selectedValues = collected.values; // 選択された値を取得
         selectedValues.forEach((value) => {

--- a/commands/register/team.js
+++ b/commands/register/team.js
@@ -46,6 +46,9 @@ async function team(interaction) {
             time: 60000 // 60秒間収集
         });
 
+        // 相互作用トークンを確保して Unknown interaction を防ぐ
+        await collected.defer();
+
         const selectedValues = collected.values; // 選択された値を取得
         selectedValues.forEach((value) => {
             const teamName = teamNames[value];
@@ -54,7 +57,7 @@ async function team(interaction) {
             }
         });
 
-        await collected.reply({ content: `選択された班: ${collectedTeams.join(', ')}`});
+        await collected.followUp({ content: `選択された班: ${collectedTeams.join(', ')}`});
         return collectedTeams; // 選択された班の配列を返す
     } catch (error) {
         if (error.code === 'InteractionCollectorError') {

--- a/sqlite.js
+++ b/sqlite.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const { createCanvas, loadImage } = require('canvas'); // canvasライブラリを使用
 
 const db = new Database('data/casru.db');
+db.pragma('busy_timeout = 5000');  // SQLiteの同時書き込み時に5秒待機
 
 // テーブルが存在しない場合にのみ作成する
 const createTweetTableQuery = db.prepare(`
@@ -156,76 +157,67 @@ function getQRCodeByCode(qrCode) {
 }
 
 function updatePaymentByQRCode(discordId, qrCode) {
-    const qrRow = getQRCodeByCode(qrCode);
-    if (!qrRow) {
-        return {
-            ok: false,
-            message: 'QRコードがデータベースに存在しません。',
-            code: 'QR_NOT_FOUND',
-        };
+    try {
+        const updatePaymentTransaction = db.transaction(() => {
+            // ✅ トランザクション内ですべてのチェックを実行
+            const qrRow = db.prepare(`
+                SELECT * FROM QRCode WHERE qr_code = ?;
+            `).get(qrCode);
+
+            if (!qrRow) {
+                throw { ok: false, message: 'QRコードがデータベースに存在しません。', code: 'QR_NOT_FOUND' };
+            }
+
+            if (qrRow.discord_id !== 'none') {
+                throw { ok: false, message: 'このQRコードはすでに使用されています。', code: 'QR_ALREADY_USED' };
+            }
+
+            const memberRow = db.prepare(`
+                SELECT * FROM Member_Information WHERE discord_id = ?;
+            `).get(discordId);
+
+            if (!memberRow) {
+                throw { ok: false, message: '会員情報が見つかりませんでした。', code: 'MEMBER_NOT_FOUND' };
+            }
+
+            const grade = Number(memberRow.grade);
+            const price = Number(qrRow.price);
+
+            if (grade <= 4 && price !== 5000) {
+                throw { ok: false, message: 'このQRコードは院生または外部生用です。役員に問い合わせてください。', code: 'PRICE_MISMATCH_UNDERGRAD' };
+            }
+
+            if (grade > 4 && price !== 2500) {
+                throw { ok: false, message: 'このQRコードは学部生用です。役員に問い合わせてください。', code: 'PRICE_MISMATCH_GRAD' };
+            }
+
+            const currentDate = new Date().toISOString();
+
+            // ✅ ここで初めてデータベースを更新
+            db.prepare(`
+                UPDATE Member_Information
+                SET last_payment_date = ?
+                WHERE discord_id = ?;
+            `).run(currentDate, discordId);
+
+            db.prepare(`
+                UPDATE QRCode
+                SET discord_id = ?
+                WHERE qr_code = ?;
+            `).run(discordId, qrCode);
+
+            return { ok: true, message: `${price}円の支払いが完了しました。`, code: 'PAYMENT_UPDATED', paymentDate: currentDate, price };
+        });
+
+        return updatePaymentTransaction();
+    } catch (error) {
+        if (error && error.ok === false) {
+            return error; // バリデーションエラー
+        }
+        // SQLITE_BUSY などのDBエラー
+        console.error('updatePaymentByQRCode - DBエラー:', error);
+        return { ok: false, message: '処理中にエラーが発生しました。もう一度お試しください。', code: 'DB_ERROR' };
     }
-
-    if (qrRow.discord_id !== 'none') {
-        return {
-            ok: false,
-            message: 'このQRコードはすでに使用されています。',
-            code: 'QR_ALREADY_USED',
-        };
-    }
-
-    const memberRow = getDataBydiscord_id(discordId);
-    if (!memberRow) {
-        return {
-            ok: false,
-            message: '会員情報が見つかりませんでした。',
-            code: 'MEMBER_NOT_FOUND',
-        };
-    }
-
-    const grade = Number(memberRow.grade);
-    const price = Number(qrRow.price);
-
-    if (grade <= 4 && price !== 5000) {
-        return {
-            ok: false,
-            message: 'このQRコードは院生または外部生用です。役員に問い合わせてください。',
-            code: 'PRICE_MISMATCH_UNDERGRAD',
-        };
-    }
-
-    if (grade > 4 && price !== 2500) {
-        return {
-            ok: false,
-            message: 'このQRコードは学部生用です。役員に問い合わせてください。',
-            code: 'PRICE_MISMATCH_GRAD',
-        };
-    }
-
-    const currentDate = new Date().toISOString();
-
-    const updatePaymentTransaction = db.transaction(() => {
-        db.prepare(`
-            UPDATE Member_Information
-            SET last_payment_date = ?
-            WHERE discord_id = ?;
-        `).run(currentDate, discordId);
-
-        db.prepare(`
-            UPDATE QRCode
-            SET discord_id = ?
-            WHERE qr_code = ?;
-        `).run(discordId, qrCode);
-    });
-
-    updatePaymentTransaction();
-
-    return {
-        ok: true,
-        message: `${price}円の支払いが完了しました。`,
-        code: 'PAYMENT_UPDATED',
-        paymentDate: currentDate,
-        price,
-    };
 }
 
 // データベース内のすべてのQRコードをPNGファイルとして生成する関数


### PR DESCRIPTION
Add SQLite busy_timeout and refactor updatePaymentByQRCode to run validations and updates inside a single transaction. The new implementation performs QR/member checks, price/grade validations, updates Member_Information and QRCode atomically, and returns structured error objects for validation failures or a DB_ERROR for unexpected DB issues. Also update commands/newpay.js and commands/pay.js to handle failed paymentResult (showing an ephemeral system error message) before replying with success messages.