### PR TITLE
Harden MemberBot Docker migration configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,6 @@
 node_modules
+.git
+.env
+data/
+casrudb_dump/
+qrcodes/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM node:slim
+# Migration reproducibility: better-sqlite3 11.9.1 does not build on Node 26.
+# This is the exact Node base used by the last known-good Snap Docker image.
+FROM node:25.9.0-bookworm-slim@sha256:e49fd70491eb042270f974167c874d6245287263ffc16422fcf93b3c150409d8
 
 WORKDIR /app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,12 +10,12 @@ services:
     env_file:
       - .env
     environment:
-      - DISCORD_TOKEN:${DISCORD_TOKEN}
-      - CLIENT_ID:${CLIENT_ID}
-      - GUILD_ID:${GUILD_ID}
-      - PASSWORD:${PASSWORD}
-      - ZBARIMG_EXECUTABLE:${ZBARIMG_EXECUTABLE}
-      - ADMIN_PASSWORD:${ADMIN_PASSWORD}
+      DISCORD_TOKEN: ${DISCORD_TOKEN}
+      CLIENT_ID: ${CLIENT_ID}
+      GUILD_ID: ${GUILD_ID}
+      PASSWORD: ${PASSWORD}
+      ZBARIMG_EXECUTABLE: ${ZBARIMG_EXECUTABLE}
+      ADMIN_PASSWORD: ${ADMIN_PASSWORD}
     restart: always
 
 volumes:


### PR DESCRIPTION
## 変更内容

- `.env`、DB、dump、QRコード、GitメタデータをDocker build contextから除外
- 移行前の稼働実績と一致するNode 25.9.0 bookworm-slimをdigest固定
- Composeの環境変数を正しいYAML mapping形式へ修正

## 理由

Docker移行後も既知の正常なNode／better-sqlite3構成を再現し、機密情報や永続データをイメージへ取り込まず、環境変数を確実にコンテナへ渡すためです。

## 影響

現在の稼働コンテナは再作成しません。次回ビルド／再作成時に適用されます。Node 25固定は移行再現性のための暫定措置であり、LTS移行は別途検証が必要です。

## 検証

- 最新`origin/main`を起点に作成
- `git diff --check`
- `docker compose config --quiet`
- `docker buildx build --check --file Dockerfile .`
- 稼働環境でNode 25.9.0とbetter-sqlite3の読み込みを確認